### PR TITLE
Add token-based authentication with per-device revocation

### DIFF
--- a/pkg/controllers.go
+++ b/pkg/controllers.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
 
@@ -108,6 +109,31 @@ func DeleteAllFiles(ctx *gin.Context) {
 	}
 	ctx.Redirect(http.StatusFound, "/files")
 }
+func RevokeDevice(ctx *gin.Context) {
+	session := sessions.Default(ctx)
+	myToken, _ := session.Get("auth_token").(string)
+
+	channel.mu.RLock()
+	me, ok := channel.connected_devices[myToken]
+	channel.mu.RUnlock()
+	if !ok || !me["isHost"].Flag {
+		ctx.AbortWithStatus(http.StatusForbidden)
+		return
+	}
+
+	token := ctx.Param("token")
+	if token == myToken {
+		ctx.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	channel.mu.Lock()
+	delete(channel.connected_devices, token)
+	channel.mu.Unlock()
+
+	ctx.Redirect(http.StatusFound, "/connected_devices")
+}
+
 func DeleteFile(ctx *gin.Context) {
 	path, err := filepath.Abs("sync.io-cache")
 	if err != nil {

--- a/pkg/middleware.go
+++ b/pkg/middleware.go
@@ -1,54 +1,74 @@
 package router
 
 import (
+	"net/http"
 	"time"
 
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/mileusna/useragent"
 )
 
-func sessionMiddleware() gin.HandlerFunc {
-	return traceDevices
+func authMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		session := sessions.Default(c)
+		token, _ := session.Get("auth_token").(string)
+
+		channel.mu.RLock()
+		_, valid := channel.connected_devices[token]
+		deviceCount := len(channel.connected_devices)
+		noPassword := channel.password == ""
+		channel.mu.RUnlock()
+
+		if valid {
+			c.Next()
+			return
+		}
+
+		if deviceCount == 0 {
+			c.Redirect(http.StatusFound, "/setpassword")
+			c.Abort()
+			return
+		}
+
+		// No password set: auto-issue a token so the user gets in seamlessly.
+		if noPassword {
+			issueToken(c, false)
+			c.Next()
+			return
+		}
+
+		c.Redirect(http.StatusFound, "/verifypassword")
+		c.Abort()
+	}
 }
 
-func traceDevices(c *gin.Context) {
-	remoteIp := c.RemoteIP()
-	connected_devices := channel.connected_devices
-	_, ok := connected_devices[remoteIp]
-	currentTime := time.Now()
-	if ok {
-		// val["last_connected"] = StringBool{Str: currentTime.Format("15:04:00 PM")}
-		return
-	} else {
-		ua := useragent.Parse(c.GetHeader("user-agent"))
-		print(ua.Device)
-		if len(connected_devices) == 0 {
-			device_map := make(map[string]StringBool)
-
-			device_map["name"] = StringBool{Str: ua.Name + " (Host)"}
-			device_map["os"] = StringBool{Str: ua.OS}
-			device_map["mobile"] = StringBool{Flag: ua.Mobile}
-			device_map["ip"] = StringBool{Str: remoteIp}
-			device_map["connected"] = StringBool{Str: currentTime.Format("15:04:00 PM")}
-			// device_map["last_connected"] = StringBool{Str: currentTime.Format("15:04:00 PM")}
-			connected_devices[remoteIp] = device_map
-			c.Redirect(302, "/setpassword")
-		} else {
-			device_map := make(map[string]StringBool)
-
-			device_map["name"] = StringBool{Str: ua.Name}
-			device_map["os"] = StringBool{Str: ua.OS}
-			device_map["mobile"] = StringBool{Flag: ua.Mobile}
-			device_map["ip"] = StringBool{Str: remoteIp}
-			device_map["connected"] = StringBool{Str: currentTime.Format("15:04:00 PM")}
-			// device_map["last_connected"] = StringBool{Str: currentTime.Format("15:04:00 PM")}
-
-			connected_devices[remoteIp] = device_map
-			if channel.password != "" {
-				c.Redirect(302, "/verifypassword")
-			}
-		}
+// issueToken creates a new auth token for the device, stores it server-side,
+// and writes it to the session cookie.
+func issueToken(c *gin.Context, isHost bool) {
+	ua := useragent.Parse(c.GetHeader("user-agent"))
+	token := generateToken()
+	name := ua.Name
+	if isHost {
+		name += " (Host)"
 	}
+	device := map[string]StringBool{
+		"name":      {Str: name},
+		"os":        {Str: ua.OS},
+		"mobile":    {Flag: ua.Mobile},
+		"ip":        {Str: c.RemoteIP()},
+		"connected": {Str: time.Now().Format("15:04:00 PM")},
+		"isHost":    {Flag: isHost},
+		"token":     {Str: token},
+	}
+
+	channel.mu.Lock()
+	channel.connected_devices[token] = device
+	channel.mu.Unlock()
+
+	session := sessions.Default(c)
+	session.Set("auth_token", token)
+	session.Save()
 }
 
 func cacheMiddleware() gin.HandlerFunc {

--- a/pkg/model.go
+++ b/pkg/model.go
@@ -1,13 +1,28 @@
 package router
 
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+)
+
 type StringBool struct {
 	Str  string
 	Flag bool
 }
 
 type Channel struct {
+	mu                sync.RWMutex
 	password          string
 	connected_devices map[string]map[string]StringBool
+}
+
+func generateToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
 }
 
 func setPassword(password string) {
@@ -15,11 +30,10 @@ func setPassword(password string) {
 		channel.password = hashAndSalt([]byte(password))
 	}
 }
+
 func verifyPassword(password string) bool {
-	hash := hashAndSalt([]byte(password))
-	if hash == channel.password {
-		return false
-	} else {
+	if channel.password == "" {
 		return true
 	}
+	return checkPassword(password, channel.password)
 }

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -36,52 +36,98 @@ func Router() *gin.Engine {
 	channel = new(Channel)
 	channel.connected_devices = make(map[string]map[string]StringBool)
 	r.SetHTMLTemplate(tmpl)
-	r.Use(sessionMiddleware())
 	r.Use(gin.Recovery())
 	r.Use(brotli.Brotli(brotli.DefaultCompression))
+
+	// Static assets — no auth required (needed by login pages too).
 	static := r.Group("/")
 	{
 		static.Use(cacheMiddleware())
 		fs, _ := io.Sub(staticFiles, "templates/static")
 		static.StaticFS("/static/", http.FS(fs))
 	}
-	r.GET("/", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "index.html", gin.H{})
-	})
-	r.GET("/files", ListFiles)
-	r.GET("/upload", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "upload.html", gin.H{"csrf": csrf.GetToken(c)})
-	})
-	r.POST("/upload", UploadFiles)
-	r.GET("/connected_devices", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "connectedDevices.html", gin.H{"devices": channel.connected_devices})
-	})
-	r.GET("/qr", func(c *gin.Context) {
-		c.HTML(http.StatusOK, "generateQR.html", gin.H{"qr": generateQR()})
-	})
-	r.GET("/download/:filename", DownloadFile)
-	r.GET("/preview/:filename", PreviewFile)
-	r.GET("/delete/:filename", DeleteFile)
-	r.GET("/downloadAll", DownloadAllFiles)
-	r.GET("/deleteAll", DeleteAllFiles)
+
+	// Auth pages — intentionally outside the protected group.
 	r.GET("/setpassword", func(c *gin.Context) {
+		channel.mu.RLock()
+		deviceCount := len(channel.connected_devices)
+		channel.mu.RUnlock()
+		if deviceCount > 0 {
+			c.Redirect(http.StatusFound, "/verifypassword")
+			return
+		}
 		c.HTML(http.StatusOK, "setPassword.html", gin.H{"csrf": csrf.GetToken(c)})
 	})
+	r.POST("/setpassword", func(c *gin.Context) {
+		channel.mu.RLock()
+		deviceCount := len(channel.connected_devices)
+		channel.mu.RUnlock()
+		if deviceCount > 0 {
+			c.Redirect(http.StatusFound, "/verifypassword")
+			return
+		}
+		setPassword(c.PostForm("password"))
+		issueToken(c, true)
+		c.Redirect(http.StatusFound, "/")
+	})
 	r.GET("/verifypassword", func(c *gin.Context) {
+		session := sessions.Default(c)
+		token, _ := session.Get("auth_token").(string)
+		channel.mu.RLock()
+		_, valid := channel.connected_devices[token]
+		channel.mu.RUnlock()
+		if valid {
+			c.Redirect(http.StatusFound, "/")
+			return
+		}
 		c.HTML(http.StatusOK, "verifyPassword.html", gin.H{"csrf": csrf.GetToken(c)})
 	})
-	r.POST("/setpassword", func(c *gin.Context) {
-		password := c.PostForm("password")
-		setPassword(password)
-		c.Redirect(302, "/")
-	})
 	r.POST("/verifypassword", func(c *gin.Context) {
-		password := c.PostForm("password")
-		iscorrect := verifyPassword(password)
-		if iscorrect {
-			c.Redirect(302, "/")
+		if verifyPassword(c.PostForm("password")) {
+			issueToken(c, false)
+			c.Redirect(http.StatusFound, "/")
+			return
 		}
+		c.HTML(http.StatusUnauthorized, "verifyPassword.html", gin.H{
+			"csrf":  csrf.GetToken(c),
+			"error": "Incorrect password. Please try again.",
+		})
 	})
+
+	// Protected routes — all require a valid server-side token.
+	protected := r.Group("/")
+	protected.Use(authMiddleware())
+	{
+		protected.GET("/", func(c *gin.Context) {
+			c.HTML(http.StatusOK, "index.html", gin.H{})
+		})
+		protected.GET("/files", ListFiles)
+		protected.GET("/upload", func(c *gin.Context) {
+			c.HTML(http.StatusOK, "upload.html", gin.H{"csrf": csrf.GetToken(c)})
+		})
+		protected.POST("/upload", UploadFiles)
+		protected.GET("/connected_devices", func(c *gin.Context) {
+			session := sessions.Default(c)
+			myToken, _ := session.Get("auth_token").(string)
+			channel.mu.RLock()
+			me := channel.connected_devices[myToken]
+			devices := channel.connected_devices
+			channel.mu.RUnlock()
+			c.HTML(http.StatusOK, "connectedDevices.html", gin.H{
+				"devices": devices,
+				"isHost":  me["isHost"].Flag,
+			})
+		})
+		protected.GET("/qr", func(c *gin.Context) {
+			c.HTML(http.StatusOK, "generateQR.html", gin.H{"qr": generateQR()})
+		})
+		protected.GET("/download/:filename", DownloadFile)
+		protected.GET("/preview/:filename", PreviewFile)
+		protected.GET("/delete/:filename", DeleteFile)
+		protected.GET("/downloadAll", DownloadAllFiles)
+		protected.GET("/deleteAll", DeleteAllFiles)
+		protected.GET("/revoke/:token", RevokeDevice)
+	}
 
 	return r
 }

--- a/pkg/templates/tailwind/connectedDevices.html
+++ b/pkg/templates/tailwind/connectedDevices.html
@@ -1,15 +1,15 @@
 {{template "base.html" .}}
 
       <!-- Main Section -->
-      <div class="p-4 sm:ml-64 bg-backgroundColorLight dark:bg-backgroundColorDark md:h-max h-screen">        
+      <div class="p-4 sm:ml-64 bg-backgroundColorLight dark:bg-backgroundColorDark md:h-max h-screen">
             <div class="p-4 relative overflow-x-auto shadow-md sm:rounded-lg mt-16">
                   <table class="w-full text-sm text-left rtl:text-right text-white">
                         <caption class="p-5 text-lg font-semibold text-left rtl:text-right text-white bg-navbarLight dark:bg-navbarDark">
                               Connected Devices
                               <p class="mt-1 text-sm font-normal text-gray-300 dark:text-gray-400">
                                     Devices which were connected to this server
-                              </p>  
-                        </caption>  
+                              </p>
+                        </caption>
                         <thead class="text-xs text-gray-700 uppercase bg-gray-50">
                               <tr>
                                     <th scope="col" class="px-6 py-3">
@@ -19,11 +19,16 @@
                                           Operating System
                                     </th>
                                     <th scope="col" class="px-6 py-3">
-                                          IP Addres
+                                          IP Address
                                     </th>
                                     <th scope="col" class="px-6 py-3">
                                           Connected At
                                     </th>
+                                    {{if .isHost}}
+                                    <th scope="col" class="px-6 py-3">
+                                          Actions
+                                    </th>
+                                    {{end}}
                               </tr>
                         </thead>
 
@@ -52,12 +57,25 @@
                                     <td class="px-6 py-4 text-black">
                                           {{.connected.Str}}
                                     </td>
+                                    {{if $.isHost}}
+                                    <td class="px-6 py-4">
+                                          {{if not .isHost.Flag}}
+                                          <a href="/revoke/{{.token.Str}}"
+                                                onclick="return confirm('Revoke access for this device?')"
+                                                class="font-medium text-red-500 hover:underline">
+                                                Revoke
+                                          </a>
+                                          {{else}}
+                                          <span class="text-gray-400 text-xs">Host</span>
+                                          {{end}}
+                                    </td>
+                                    {{end}}
                               </tr>
                               {{end}}
                         </tbody>
                   </table>
-            </div>   
-      </div>      
+            </div>
+      </div>
 </body>
 
 </html>

--- a/pkg/templates/tailwind/verifyPassword.html
+++ b/pkg/templates/tailwind/verifyPassword.html
@@ -40,6 +40,10 @@
                               Enter the password that has been set while starting the server.
                         </p>
 
+                        {{if .error}}
+                        <p class="text-red-400 text-sm mt-1 mb-2">{{.error}}</p>
+                        {{end}}
+
                         <!-- Password -->
                         <div class="mb-4">
                               <label for="password" class=" mt-2 block text-gray-300 font-semibold text-sm">

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -42,18 +42,16 @@ func OpenBrowser(url string) {
 	}
 }
 func hashAndSalt(pwd []byte) string {
-
-	// Use GenerateFromPassword to hash & salt pwd.
-	// MinCost is just an integer constant provided by the bcrypt
-	// package along with DefaultCost & MaxCost.
-	// The cost can be any value you want provided it isn't lower
-	// than the MinCost (4)
 	hash, err := bcrypt.GenerateFromPassword(pwd, bcrypt.DefaultCost)
 	if err != nil {
 		log.Println(err)
-	} // GenerateFromPassword returns a byte slice so we need to
-	// convert the bytes to a string and return it
+	}
 	return string(hash)
+}
+
+func checkPassword(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
 }
 
 func generateQR() string {


### PR DESCRIPTION
Replace IP-based session tracking with cryptographically random per-device tokens. On authentication, a 64-char hex token is issued, stored server-side in connected_devices, and persisted in the signed session cookie. Every subsequent request is validated against the server-side map — an IP match alone is no longer sufficient.

Fix a critical bug in verifyPassword: the old code compared two independently generated bcrypt hashes with ==, which is always false due to bcrypt's random salting, so every password attempt silently succeeded. Now uses bcrypt.CompareHashAndPassword for correct verification.

Add host-only device revocation: the host sees a Revoke button next to each connected device in the Connected Devices page. Revoking removes the token server-side; the affected device is bounced to /verifypassword on their next request regardless of what cookie they hold.

Restructure the router into explicit public routes (/setpassword, /verifypassword) and a protected group behind authMiddleware, so login pages are reachable before authentication without needing special-case checks inside the middleware.

Add sync.RWMutex to Channel to protect concurrent map reads and writes across goroutines, fixing a pre-existing data race.

Show an error message on the verify-password page when the password is wrong, instead of silently re-rendering the form.